### PR TITLE
Feature/users create

### DIFF
--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -1,5 +1,14 @@
-import { Column, Entity, JoinTable, ManyToMany, OneToMany } from 'typeorm';
+import {
+  BeforeInsert,
+  Column,
+  Entity,
+  JoinTable,
+  ManyToMany,
+  OneToMany,
+} from 'typeorm';
+import * as bcrypt from 'bcrypt';
 import { CoreEntity } from '../../core/entities/core.entity';
+import { InternalServerErrorException } from '@nestjs/common';
 
 @Entity()
 export class User extends CoreEntity {
@@ -14,6 +23,15 @@ export class User extends CoreEntity {
 
   @Column({ type: 'datetime', nullable: true })
   loginedAt: Date;
+
+  @BeforeInsert()
+  async hashPassword(): Promise<void> {
+    try {
+      this.password = await bcrypt.hash(this.password, 10);
+    } catch (e) {
+      throw new InternalServerErrorException();
+    }
+  }
 
   // 나중에 프로젝트, 게임 테이블 생성되면 주석해제
   // @OneToMany((_type) => Project, (project) => project.user, {

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -1,5 +1,6 @@
-import { Body, Controller, HttpException, Post } from '@nestjs/common';
+import { Body, Controller, Post } from '@nestjs/common';
 import { CreateUserDto } from './dto/create-user.dto';
+import { User } from './entities/user.entity';
 import { UsersService } from './users.service';
 
 @Controller('users')
@@ -7,14 +8,7 @@ export class UsersController {
   constructor(private readonly usersService: UsersService) {}
 
   @Post()
-  async createUser(@Body() createBody: CreateUserDto) {
-    const result = await this.usersService.createUser(createBody);
-    if (result.ok) {
-      return {
-        message: '회원가입에 성공하였습니다.',
-      };
-    } else {
-      throw new HttpException(result.error, result.htmlStatus);
-    }
+  async createUser(@Body() createBody: CreateUserDto): Promise<User> {
+    return await this.usersService.createUser(createBody);
   }
 }

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -7,9 +7,7 @@ import { UsersService } from './users.service';
 @Module({
   imports: [TypeOrmModule.forFeature([User])],
   controllers: [UsersController],
-  providers: [UsersService],
   exports: [UsersService],
-  controllers: [UsersController],
-  providers: [UsersService]
+  providers: [UsersService],
 })
 export class UsersModule {}


### PR DESCRIPTION
## 작업 분류

- [ ] 버그 수정
- [x] 신규 기능 추가
- [x] 리팩터링
- [ ] 테스트

## 작업 개요
- users 리턴타입 변경, 패스워드 암호화 entity 추가 

## 상세 내용
- users controller 와 service의 리턴타입을 변경했습니다. 

```ts
@Post()
  async createUser(@Body() createBody: CreateUserDto): Promise<User> {
    return await this.usersService.createUser(createBody);
  }
```

```ts
 async createUser({
    email,
    password,
    nickname,
  }: CreateUserDto): Promise<User> {
    const existUser = this.usersRepository.findOne({ email });
    if (existUser) {
      throw new ConflictException('이미 가입된 이메일입니다.');
    }

    const user = this.usersRepository.create({ email, password, nickname });
    try {
      return await this.usersRepository.save(user);
    } catch (error) {
      throw new InternalServerErrorException(
        '회원 가입에 오류가 발생하였습니다.',
      );
    }
  }
```

- entity.ts 에 bcrypt 패스워드를 추가했습니다. 
```ts
  @BeforeInsert()
  async hashPassword(): Promise<void> {
    try {
      this.password = await bcrypt.hash(this.password, 10);
    } catch (e) {
      throw new InternalServerErrorException();
    }
  }
```


resolves: #27