### PR TITLE
fix: user create

### DIFF
--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, HttpException, Post } from '@nestjs/common';
+import { Body, Controller, Post } from '@nestjs/common';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UsersService } from './users.service';
 
@@ -8,14 +8,6 @@ export class UsersController {
 
   @Post()
   async createUser(@Body() createBody: CreateUserDto) {
-    const result = await this.usersService.createUser(createBody);
-    if (result.ok) {
-      return {
-        message: '회원가입에 성공하였습니다.',
-      };
-    } else {
-      throw new HttpException(result.error, result.htmlStatus);
-    }
+    return await this.usersService.createUser(createBody);
   }
 }
-

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -9,7 +9,5 @@ import { UsersService } from './users.service';
   controllers: [UsersController],
   providers: [UsersService],
   exports: [UsersService],
-  controllers: [UsersController],
-  providers: [UsersService]
 })
 export class UsersModule {}

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -21,7 +21,7 @@ export class UsersService {
     password,
     nickname,
   }: CreateUserDto): Promise<User> {
-    const existUser = this.usersRepository.findOne({ email });
+    const existUser = await this.usersRepository.findOne({ email });
     if (existUser) {
       throw new ConflictException('이미 가입된 이메일입니다.');
     }


### PR DESCRIPTION
## 작업 분류

- [x] 버그 수정
- [ ] 신규 기능 추가
- [ ] 리팩터링
- [ ] 테스트

## 작업 개요
- user create 실패에 관련된 코드 수정

## 상세 내용
- user module에서 providers와 controllers 수정

src/users/users.module.ts
```ts
@Module({
  imports: [TypeOrmModule.forFeature([User])],
  controllers: [UsersController],
  providers: [UsersService],
  exports: [UsersService],
})
```

src/users/users.controller.ts
```ts
  @Post()
  async createUser(@Body() createBody: CreateUserDto) {
    return await this.usersService.createUser(createBody);
  }
```

- user service의 createUser()에서 findOne에 대한 await 처리

src/users/users.service.ts

```
    const existUser = await this.usersRepository.findOne({ email });
```


resolves: #48 