### PR TITLE
feat: 게임 전체 및 상세 조회때 좋아요 숫자와 리스트 출력

### DIFF
--- a/src/game/entities/game.entity.ts
+++ b/src/game/entities/game.entity.ts
@@ -31,7 +31,6 @@ export class Game extends CoreEntity {
   project: Project;
 
   @ManyToOne((_type) => User, (user) => user.games, {
-    eager: true,
     onDelete: 'CASCADE',
   })
   user: User;

--- a/src/game/game.controller.ts
+++ b/src/game/game.controller.ts
@@ -17,6 +17,7 @@ import { CreateGameDto } from './dto/create-game.dto';
 import { UpdateGameDto } from './dto/update-game.dto';
 import { Game } from './entities/game.entity';
 import { GameService } from './game.service';
+
 @Controller('game')
 export class GameController {
   constructor(

--- a/src/game/game.repository.ts
+++ b/src/game/game.repository.ts
@@ -53,4 +53,25 @@ export class GameRepository extends Repository<Game> {
       throw new InternalServerErrorException();
     }
   }
+
+  async findOneGame(id: number) {
+    const game = await this.createQueryBuilder('game')
+      .loadRelationCountAndMap('game.likeCount', 'game.likes')
+      .leftJoin('game.likes', 'likes')
+      .addSelect('likes.email')
+      .where('game.id = :id', { id: id })
+      .getOne();
+    return game;
+  }
+
+  async findGames(limit: number, offset: number): Promise<Game[]> {
+    const game = await this.createQueryBuilder('game')
+      .leftJoin('game.likes', 'likes')
+      .addSelect('likes.email')
+      .limit(limit)
+      .offset(offset)
+      .loadRelationCountAndMap('game.likeCount', 'game.likes')
+      .getMany();
+    return game;
+  }
 }

--- a/src/game/game.service.ts
+++ b/src/game/game.service.ts
@@ -20,10 +20,6 @@ export class GameService {
     private gameRepository: GameRepository,
   ) {}
 
-  async getGames(limit: number, offset: number): Promise<Game[]> {
-    return await this.gameRepository.find({ skip: offset, take: limit });
-  }
-
   createGame(
     createGameDto: CreateGameDto,
     project: Project,
@@ -32,8 +28,12 @@ export class GameService {
     return this.gameRepository.createGame(createGameDto, project, user);
   }
 
+  getGames(limit: number, offset: number): Promise<Game[]> {
+    return this.gameRepository.findGames(limit, offset);
+  }
+
   async getGameById(id: number, addViewCount = false): Promise<Game> {
-    const game = await this.gameRepository.findOne({ id });
+    const game = await this.gameRepository.findOneGame(id);
     if (!game) {
       throw new NotFoundException('유효한 게임 id가 아닙니다.');
     }
@@ -75,7 +75,10 @@ export class GameService {
   }
 
   async addOrRemoveLike(id: number, user: User): Promise<{ message: string }> {
-    const game = await this.getGameById(id);
+    const game = await this.gameRepository.findOne({ id });
+    if (!game) {
+      throw new NotFoundException('유효한 게임 id가 아닙니다.');
+    }
     return this.gameRepository.addOrRemoveLike(game, user);
   }
 }


### PR DESCRIPTION
## 작업 분류

- [ ] 버그 수정
- [x] 신규 기능 추가
- [ ] 리팩터링
- [ ] 테스트

## 작업 개요
- 게임 전체 및 상세 조회때 좋아요 숫자와 리스트 출력

## 상세 내용
- 게임 전체 및 상세 조회때 좋아요 숫자와 리스트 출력하도록 로직 수정
- game.entity에서 game에 relate된 user를 출력하지 못하게 eager 옵션 제거

## 집중 요망!
- game 조회 시 'likeCount'로 좋아요 한 숫자를 확인할 수 있습니다.
- game 조회 시 'likes'에서 좋아요 한 유저들의 email들을 확인할 수 있습니다.

resolves: #11 #12